### PR TITLE
feat: add `init_client()` and `LocalClient`

### DIFF
--- a/examples/output_variables.rs
+++ b/examples/output_variables.rs
@@ -1,16 +1,16 @@
 use git_bot_feedback::{
     OutputVariable, RestClientError,
-    client::{GithubApiClient, RestApiClient},
+    client::{RestApiClient, init_client},
 };
 
 struct ClientWrapper {
-    client: Box<dyn RestApiClient>,
+    client: Box<dyn RestApiClient + Send + Sync>,
 }
 
 #[tokio::main]
 async fn main() -> Result<(), RestClientError> {
     let client_wrapper = ClientWrapper {
-        client: Box::new(GithubApiClient::new()?),
+        client: init_client()?,
     };
     let output_var = OutputVariable {
         name: "STEP_OUTPUT_VAR".to_string(),

--- a/nurfile
+++ b/nurfile
@@ -82,7 +82,7 @@ export def "nur docs" [
 export def "nur lint" [
     --check (-c) # Check only, do not apply fixes
 ] {
-    let clippy_args = [cargo, clippy, --features, file-changes]
+    let clippy_args = [cargo, clippy, --features, file-changes --all-targets]
     if $check {
         run-cmd ...$clippy_args -- -D warnings
         run-cmd cargo fmt -- --check

--- a/src/client/local.rs
+++ b/src/client/local.rs
@@ -1,0 +1,142 @@
+use super::RestApiClient;
+use crate::{OutputVariable, RestClientError as ClientError, ReviewOptions, ThreadCommentOptions};
+
+#[cfg(feature = "file-changes")]
+use crate::{FileDiffLines, FileFilter, LinesChangedOnly, parse_diff};
+#[cfg(feature = "file-changes")]
+use std::{collections::HashMap, process::Command};
+
+/// A (mostly) non-operational implementation of [`RestApiClient`].
+///
+/// This is primarily meant for use in local contexts (or in unsupported CI
+/// platforms/contexts) because the following methods silently do nothing:
+///
+/// - [`Self::post_thread_comment`]
+/// - [`Self::cull_pr_reviews`]
+/// - [`Self::post_pr_review`]
+///
+/// However, [`Self::get_list_of_changed_files`] does use the git CLI
+/// to get a list of changed files.
+///
+/// Instantiate with [`Default::default()`].
+/// ```rust
+/// use git_bot_feedback::client::LocalClient;
+///
+/// let client = LocalClient::default();
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct LocalClient;
+
+#[async_trait::async_trait]
+impl RestApiClient for LocalClient {
+    #[cfg(feature = "file-changes")]
+    async fn get_list_of_changed_files(
+        &self,
+        file_filter: &FileFilter,
+        lines_changed_only: &LinesChangedOnly,
+        base_diff: Option<String>,
+        ignore_index: bool,
+    ) -> Result<HashMap<String, FileDiffLines>, ClientError> {
+        let git_status = if ignore_index {
+            0
+        } else {
+            match Command::new("git").args(["status", "--short"]).output() {
+                Err(e) => {
+                    return Err(ClientError::io("invoke `git status`", e));
+                }
+                Ok(output) => {
+                    if output.status.success() {
+                        String::from_utf8_lossy(&output.stdout)
+                            .to_string()
+                            // trim last newline to prevent an extra empty line being counted as a changed file
+                            .trim_end_matches('\n')
+                            .lines()
+                            // we only care about staged changes
+                            .filter(|l| !l.starts_with(' '))
+                            .count()
+                    } else {
+                        let err_msg = String::from_utf8_lossy(&output.stderr).to_string();
+                        return Err(ClientError::GitCommand(err_msg));
+                    }
+                }
+            }
+        };
+        let mut diff_args = vec!["diff".to_string()];
+        if git_status != 0 {
+            // There are changes in the working directory.
+            // So, compare include the staged changes.
+            diff_args.push("--staged".to_string());
+        }
+        if let Some(base) = base_diff {
+            match Command::new("git")
+                .args(["rev-parse", base.as_str()])
+                .output()
+            {
+                Err(e) => {
+                    return Err(ClientError::Io {
+                        task: format!("invoke `git rev-parse {base}` to validate reference"),
+                        source: e,
+                    });
+                }
+                Ok(output) => {
+                    if output.status.success() {
+                        diff_args.push(base);
+                    } else if base.chars().all(|c| c.is_ascii_digit()) {
+                        // if all chars form a decimal number, then
+                        // try using it as a number of parents from HEAD
+                        diff_args.push(format!("HEAD~{base}"));
+                        // note, if still not a valid git reference, then
+                        // the error will be raised by the `git diff` command later
+                    } else {
+                        let err_msg = String::from_utf8_lossy(&output.stderr).to_string();
+                        // Given diff base did not resolve to a valid git reference
+                        return Err(ClientError::GitCommand(err_msg));
+                    }
+                }
+            }
+        } else if git_status == 0 {
+            // No base diff provided and there are no staged changes,
+            // just get the diff of the last commit.
+            diff_args.push("HEAD~1".to_string());
+        }
+        match Command::new("git").args(&diff_args).output() {
+            Err(e) => Err(ClientError::Io {
+                task: format!("invoke `git {}`", diff_args.join(" ")),
+                source: e,
+            }),
+            Ok(output) => {
+                if output.status.success() {
+                    let diff_str = String::from_utf8_lossy(&output.stdout).to_string();
+                    let files = parse_diff(&diff_str, file_filter, lines_changed_only);
+                    Ok(files)
+                } else {
+                    let err_msg = String::from_utf8_lossy(&output.stderr).to_string();
+                    Err(ClientError::GitCommand(err_msg))
+                }
+            }
+        }
+    }
+
+    fn is_pr_event(&self) -> bool {
+        false
+    }
+
+    async fn post_thread_comment(&self, _options: ThreadCommentOptions) -> Result<(), ClientError> {
+        Ok(())
+    }
+
+    async fn cull_pr_reviews(&mut self, _options: &mut ReviewOptions) -> Result<(), ClientError> {
+        Ok(())
+    }
+
+    async fn post_pr_review(&mut self, _options: &ReviewOptions) -> Result<(), ClientError> {
+        Ok(())
+    }
+
+    fn write_output_variables(&self, vars: &[OutputVariable]) -> Result<(), ClientError> {
+        for var in vars {
+            log::info!("{}: {}", var.name, var.value);
+        }
+        Ok(())
+    }
+}

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -12,15 +12,18 @@ mod github;
 #[cfg(feature = "github")]
 pub use github::GithubApiClient;
 
+mod local;
+pub use local::LocalClient;
+
 #[cfg(not(any(feature = "github", feature = "custom-git-server-impl")))]
 compile_error!(
     "At least one Git server implementation (eg. 'github') should be enabled via `features`"
 );
 
 #[cfg(feature = "file-changes")]
-use crate::{FileDiffLines, FileFilter, LinesChangedOnly, parse_diff};
+use crate::{FileDiffLines, FileFilter, LinesChangedOnly};
 #[cfg(feature = "file-changes")]
-use std::{collections::HashMap, process::Command};
+use std::collections::HashMap;
 
 /// The User-Agent header value included in all HTTP requests.
 pub static USER_AGENT: &str = concat!(env!("CARGO_CRATE_NAME"), "/", env!("CARGO_PKG_VERSION"));
@@ -92,86 +95,7 @@ pub trait RestApiClient {
         lines_changed_only: &LinesChangedOnly,
         base_diff: Option<String>,
         ignore_index: bool,
-    ) -> Result<HashMap<String, FileDiffLines>, ClientError> {
-        let git_status = if ignore_index {
-            0
-        } else {
-            match Command::new("git").args(["status", "--short"]).output() {
-                Err(e) => {
-                    return Err(ClientError::io("invoke `git status`", e));
-                }
-                Ok(output) => {
-                    if output.status.success() {
-                        String::from_utf8_lossy(&output.stdout)
-                            .to_string()
-                            // trim last newline to prevent an extra empty line being counted as a changed file
-                            .trim_end_matches('\n')
-                            .lines()
-                            // we only care about staged changes
-                            .filter(|l| !l.starts_with(' '))
-                            .count()
-                    } else {
-                        let err_msg = String::from_utf8_lossy(&output.stderr).to_string();
-                        return Err(ClientError::GitCommand(err_msg));
-                    }
-                }
-            }
-        };
-        let mut diff_args = vec!["diff".to_string()];
-        if git_status != 0 {
-            // There are changes in the working directory.
-            // So, compare include the staged changes.
-            diff_args.push("--staged".to_string());
-        }
-        if let Some(base) = base_diff {
-            match Command::new("git")
-                .args(["rev-parse", base.as_str()])
-                .output()
-            {
-                Err(e) => {
-                    return Err(ClientError::Io {
-                        task: format!("invoke `git rev-parse {base}` to validate reference"),
-                        source: e,
-                    });
-                }
-                Ok(output) => {
-                    if output.status.success() {
-                        diff_args.push(base);
-                    } else if base.chars().all(|c| c.is_ascii_digit()) {
-                        // if all chars form a decimal number, then
-                        // try using it as a number of parents from HEAD
-                        diff_args.push(format!("HEAD~{base}"));
-                        // note, if still not a valid git reference, then
-                        // the error will be raised by the `git diff` command later
-                    } else {
-                        let err_msg = String::from_utf8_lossy(&output.stderr).to_string();
-                        // Given diff base did not resolve to a valid git reference
-                        return Err(ClientError::GitCommand(err_msg));
-                    }
-                }
-            }
-        } else if git_status == 0 {
-            // No base diff provided and there are no staged changes,
-            // just get the diff of the last commit.
-            diff_args.push("HEAD~1".to_string());
-        }
-        match Command::new("git").args(&diff_args).output() {
-            Err(e) => Err(ClientError::Io {
-                task: format!("invoke `git {}`", diff_args.join(" ")),
-                source: e,
-            }),
-            Ok(output) => {
-                if output.status.success() {
-                    let diff_str = String::from_utf8_lossy(&output.stdout).to_string();
-                    let files = parse_diff(&diff_str, file_filter, lines_changed_only);
-                    Ok(files)
-                } else {
-                    let err_msg = String::from_utf8_lossy(&output.stderr).to_string();
-                    Err(ClientError::GitCommand(err_msg))
-                }
-            }
-        }
-    }
+    ) -> Result<HashMap<String, FileDiffLines>, ClientError>;
 
     /// A way to post feedback to the Git server's GUI.
     ///
@@ -224,13 +148,15 @@ pub trait RestApiClient {
     ///
     /// Not all Git servers support this on their free tiers, namely GitLab.
     fn write_file_annotations(&self, annotations: &[FileAnnotation]) -> Result<(), ClientError> {
-        println!("{annotations:#?}");
+        for annotation in annotations {
+            log::info!("{annotation:#?}");
+        }
         Ok(())
     }
 
     /// Construct a HTTP request to be sent.
     ///
-    /// The idea here is that this method is called before [`send_api_request()`].
+    /// The idea here is that this method is called before [`Self::send_api_request()`].
     /// ```ignore
     /// let request = Self::make_api_request(
     ///     &self.client,
@@ -359,5 +285,18 @@ pub trait RestApiClient {
                 log::error!("{text}");
             }
         }
+    }
+}
+
+/// Instantiate an implementation of [`RestApiClient`] based on the environment.
+///
+/// This will fallback to an instance of [`LocalClient`] if
+///
+/// - the `GITHUB_ACTIONS` environment variable is not set
+pub fn init_client() -> Result<Box<dyn RestApiClient + Send + Sync>, ClientError> {
+    if env::var("GITHUB_ACTIONS").is_ok_and(|v| v.to_lowercase() == "true") {
+        Ok(Box::new(GithubApiClient::new()?))
+    } else {
+        Ok(Box::new(LocalClient))
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,6 +22,9 @@ pub enum OutputVariableError {
     /// The output variable's value contains non-printable characters.
     #[error("The output variable's value contains non-printable characters: '{0}'")]
     ValueContainsNonPrintableCharacters(String),
+    /// Unsupported CI platform.
+    #[error("Unsupported CI platform")]
+    UnsupportedPlatform,
 }
 
 /// The possible error emitted by the REST client API

--- a/src/file_utils/file_filter.rs
+++ b/src/file_utils/file_filter.rs
@@ -314,7 +314,7 @@ mod tests {
         let mut file_filter = setup_ignore("!pybind11", &[]);
         file_filter.parse_submodules();
         assert!(file_filter.ignored.is_empty());
-        assert!(file_filter.is_file_not_ignored(&Path::new("pybind11")));
+        assert!(file_filter.is_file_not_ignored(Path::new("pybind11")));
         set_current_dir("tests/assets/ignored_paths/error").unwrap();
         file_filter.parse_submodules();
         assert!(file_filter.ignored.is_empty());
@@ -330,7 +330,7 @@ mod tests {
                     .is_file_ignored(&PathBuf::from(ignored_submodule).join("some_src.cpp"))
             );
         }
-        assert!(file_filter.not_ignored.contains(&"pybind11".to_string()));
+        assert!(file_filter.not_ignored.contains("pybind11"));
         assert!(!file_filter.is_file_not_ignored(&PathBuf::from("pybind11/some_src.cpp")));
     }
 
@@ -353,11 +353,11 @@ mod tests {
             assert!(!file.contains("\\"));
             assert!(!file.starts_with("./"));
         }
-        assert!(!file_filter.is_file_not_ignored(&Path::new(
+        assert!(!file_filter.is_file_not_ignored(Path::new(
             "tests/assets/ignored_paths/.hidden/ignore_me.txt"
         )));
-        assert!(!file_filter.is_qualified(&Path::new("tests/assets/ignored_paths/.hidden")));
-        assert!(file_filter.is_qualified(&Path::new("tests/assets/ignored_paths")));
+        assert!(!file_filter.is_qualified(Path::new("tests/assets/ignored_paths/.hidden")));
+        assert!(file_filter.is_qualified(Path::new("tests/assets/ignored_paths")));
     }
 
     #[test]

--- a/src/file_utils/mod.rs
+++ b/src/file_utils/mod.rs
@@ -172,6 +172,7 @@ mod test {
 
     #[test]
     fn get_ranges_diff() {
+        #[allow(clippy::single_range_in_vec_init)]
         let diff_chunks = vec![1..11];
         let added_lines = vec![4, 5, 9];
         let file_obj = FileDiffLines::with_info(added_lines, diff_chunks.clone());
@@ -181,6 +182,7 @@ mod test {
 
     #[test]
     fn get_ranges_added() {
+        #[allow(clippy::single_range_in_vec_init)]
         let diff_chunks = vec![1..11];
         let added_lines = vec![4, 5, 9];
         let file_obj = FileDiffLines::with_info(added_lines, diff_chunks);

--- a/src/git_diff.rs
+++ b/src/git_diff.rs
@@ -119,7 +119,7 @@ mod test {
     use super::parse_diff;
     use crate::{FileFilter, LinesChangedOnly};
 
-    const RENAMED_DIFF: &'static str = r#"diff --git a/tests/demo/some source.cpp b/tests/demo/some source.c
+    const RENAMED_DIFF: &str = r#"diff --git a/tests/demo/some source.cpp b/tests/demo/some source.c
 similarity index 100%
 rename from /tests/demo/some source.cpp
 rename to /tests/demo/some source.c
@@ -150,7 +150,7 @@ Binary files /dev/null and b/some picture.png differ
         assert!(files.is_empty());
     }
 
-    const RENAMED_DIFF_WITH_CHANGES: &'static str = r#"diff --git a/tests/demo/some source.cpp b/tests/demo/some source.c
+    const RENAMED_DIFF_WITH_CHANGES: &str = r#"diff --git a/tests/demo/some source.cpp b/tests/demo/some source.c
 similarity index 99%
 rename from /tests/demo/some source.cpp
 rename to /tests/demo/some source.c
@@ -190,7 +190,7 @@ rename to /tests/demo/some source.c
         assert!(!files.is_empty());
     }
 
-    const BINARY_DIFF: &'static str = "diff --git a/some picture.png b/some picture.png\n\
+    const BINARY_DIFF: &str = "diff --git a/some picture.png b/some picture.png\n\
                 new file mode 100644\n\
                 Binary files /dev/null and b/some picture.png differ\n";
 
@@ -204,7 +204,7 @@ rename to /tests/demo/some source.c
         assert!(files.is_empty());
     }
 
-    const TERSE_HEADERS: &'static str = r#"diff --git a/src/demo.cpp b/src/demo.cpp
+    const TERSE_HEADERS: &str = r#"diff --git a/src/demo.cpp b/src/demo.cpp
 --- a/src/demo.cpp
 +++ b/src/demo.cpp
 @@ -3 +3 @@

--- a/tests/github_file_annotations.rs
+++ b/tests/github_file_annotations.rs
@@ -1,4 +1,4 @@
-use git_bot_feedback::{FileAnnotation, RestApiClient, client::GithubApiClient};
+use git_bot_feedback::{FileAnnotation, client::init_client};
 use mockito::Server;
 use std::env;
 mod common;
@@ -14,6 +14,7 @@ const SHA: &str = "DEADBEEF";
 
 async fn write_annotations(test_params: TestParams) {
     unsafe {
+        env::set_var("GITHUB_ACTIONS", "true");
         env::set_var("GITHUB_REPOSITORY", REPO);
         env::set_var("GITHUB_SHA", SHA);
         env::set_var("CI", "true");
@@ -26,7 +27,7 @@ async fn write_annotations(test_params: TestParams) {
 
     logger_init();
     log::set_max_level(log::LevelFilter::Debug);
-    let client = GithubApiClient::new().unwrap();
+    let client = init_client().unwrap();
 
     let annotations = if test_params.empty_array {
         vec![]
@@ -46,9 +47,5 @@ async fn some_annotations() {
 
 #[tokio::test]
 async fn empty_annotations() {
-    write_annotations(TestParams {
-        empty_array: true,
-        ..Default::default()
-    })
-    .await;
+    write_annotations(TestParams { empty_array: true }).await;
 }

--- a/tests/github_file_changes.rs
+++ b/tests/github_file_changes.rs
@@ -6,8 +6,7 @@ use mockito::{Matcher, Server};
 use tempfile::{NamedTempFile, TempDir};
 
 use git_bot_feedback::{
-    DiffHunkHeader, FileFilter, LinesChangedOnly, RestApiClient, RestClientError,
-    client::GithubApiClient,
+    DiffHunkHeader, FileFilter, LinesChangedOnly, RestClientError, client::init_client,
 };
 use std::{env, io::Write, path::Path};
 
@@ -50,6 +49,7 @@ async fn get_paginated_changes(lib_root: &Path, test_params: &TestParams) {
     }
 
     unsafe {
+        env::set_var("GITHUB_ACTIONS", "true");
         env::set_var("GITHUB_REPOSITORY", REPO);
         env::set_var("GITHUB_SHA", SHA);
         env::set_var("GITHUB_TOKEN", TOKEN);
@@ -85,7 +85,7 @@ async fn get_paginated_changes(lib_root: &Path, test_params: &TestParams) {
     env::set_current_dir(tmp.path()).unwrap();
     logger_init();
     log::set_max_level(log::LevelFilter::Debug);
-    let client = match GithubApiClient::new() {
+    let client = match init_client() {
         Ok(c) => c,
         Err(e) => {
             if test_params.fail_serde_event_payload {
@@ -145,7 +145,7 @@ async fn get_paginated_changes(lib_root: &Path, test_params: &TestParams) {
         None
     };
     let file_filter = FileFilter::new(&["", "!src/*"], &["cpp", "hpp"], log_scope);
-    assert!(file_filter.is_file_ignored(&Path::new("./Cargo.toml")));
+    assert!(file_filter.is_file_ignored(Path::new("./Cargo.toml")));
     let files = client
         .get_list_of_changed_files(&file_filter, &LinesChangedOnly::Off, None, false)
         .await;

--- a/tests/github_output_variables.rs
+++ b/tests/github_output_variables.rs
@@ -1,4 +1,4 @@
-use git_bot_feedback::{OutputVariable, RestApiClient, RestClientError, client::GithubApiClient};
+use git_bot_feedback::{OutputVariable, RestClientError, client::init_client};
 use mockito::Server;
 use std::{env, io::Read, path::Path};
 use tempfile::{NamedTempFile, tempdir};
@@ -39,6 +39,7 @@ async fn append_output_vars(test_params: TestParams) -> String {
     }
 
     unsafe {
+        env::set_var("GITHUB_ACTIONS", "true");
         env::set_var("GITHUB_REPOSITORY", REPO);
         env::set_var("GITHUB_SHA", SHA);
         env::set_var("CI", "true");
@@ -52,7 +53,7 @@ async fn append_output_vars(test_params: TestParams) -> String {
     env::set_current_dir(tmp_dir.path()).unwrap();
     logger_init();
     log::set_max_level(log::LevelFilter::Debug);
-    let client = GithubApiClient::new().unwrap();
+    let client = init_client().unwrap();
 
     let out_vars = if test_params.bad_var {
         [OutputVariable {

--- a/tests/github_pr_reviews.rs
+++ b/tests/github_pr_reviews.rs
@@ -1,7 +1,6 @@
 use chrono::Utc;
 use git_bot_feedback::{
-    RestApiClient, RestClientError, ReviewAction, ReviewComment, ReviewOptions,
-    client::GithubApiClient,
+    RestClientError, ReviewAction, ReviewComment, ReviewOptions, client::init_client,
 };
 use mockito::{Matcher, Server};
 use std::{collections::HashMap, env, fmt::Display, fs, io::Write, path::Path};
@@ -156,6 +155,7 @@ impl TestControlVars {
 /// then run the parametrized test for PR review management.
 async fn setup_and_run(lib_root: &Path, test_params: &TestParams) {
     unsafe {
+        env::set_var("GITHUB_ACTIONS", "true");
         env::set_var(
             "GITHUB_EVENT_NAME",
             test_params.event_t.to_string().as_str(),
@@ -203,8 +203,8 @@ async fn setup_and_run(lib_root: &Path, test_params: &TestParams) {
 
     logger_init();
     log::set_max_level(log::LevelFilter::Debug);
-    let mut client = GithubApiClient::new().unwrap();
-    assert!(client.debug_enabled);
+    let mut client = init_client().unwrap();
+    assert!(client.is_debug_enabled());
 
     let mut mocks = vec![];
 
@@ -442,7 +442,7 @@ async fn setup_and_run(lib_root: &Path, test_params: &TestParams) {
     let mut opts = ReviewOptions {
         marker: MARKER.to_string(),
         action: test_params.action.clone(),
-        summary: summary,
+        summary,
         comments: test_control_vars.new_review_comments.clone(),
         delete_review_comments: test_params.delete_outdated,
         ..Default::default()

--- a/tests/github_step_summary.rs
+++ b/tests/github_step_summary.rs
@@ -1,4 +1,4 @@
-use git_bot_feedback::{RestApiClient, RestClientError, client::GithubApiClient};
+use git_bot_feedback::{RestClientError, client::init_client};
 use mockito::Server;
 use std::{env, io::Read, path::Path};
 use tempfile::{NamedTempFile, tempdir};
@@ -37,6 +37,7 @@ async fn append_summary(test_params: TestParams) -> String {
     }
 
     unsafe {
+        env::set_var("GITHUB_ACTIONS", "true");
         env::set_var("GITHUB_REPOSITORY", REPO);
         env::set_var("GITHUB_SHA", SHA);
         env::set_var("CI", "true");
@@ -50,7 +51,7 @@ async fn append_summary(test_params: TestParams) -> String {
     env::set_current_dir(tmp_dir.path()).unwrap();
     logger_init();
     log::set_max_level(log::LevelFilter::Debug);
-    let client = GithubApiClient::new().unwrap();
+    let client = init_client().unwrap();
 
     let mut step_summary_content = String::new();
     match client.append_step_summary(COMMENT) {

--- a/tests/github_thread_comments.rs
+++ b/tests/github_thread_comments.rs
@@ -1,7 +1,6 @@
 use chrono::Utc;
 use git_bot_feedback::{
-    CommentKind, CommentPolicy, RestApiClient, RestClientError, ThreadCommentOptions,
-    client::GithubApiClient,
+    CommentKind, CommentPolicy, RestClientError, ThreadCommentOptions, client::init_client,
 };
 use mockito::{Matcher, Server};
 use std::{env, fmt::Display, io::Write, path::Path};
@@ -75,6 +74,7 @@ impl Default for TestParams {
 
 async fn setup(lib_root: &Path, test_params: &TestParams) {
     unsafe {
+        env::set_var("GITHUB_ACTIONS", "true");
         env::set_var(
             "GITHUB_EVENT_NAME",
             test_params.event_t.to_string().as_str(),
@@ -136,7 +136,7 @@ async fn setup(lib_root: &Path, test_params: &TestParams) {
 
     logger_init();
     log::set_max_level(log::LevelFilter::Debug);
-    let client = match GithubApiClient::new() {
+    let client = match init_client() {
         Ok(c) => c,
         Err(e) => {
             if test_params.no_pr_info_env_var

--- a/tests/local_client.rs
+++ b/tests/local_client.rs
@@ -1,8 +1,8 @@
-use async_trait::async_trait;
 use chrono::Utc;
 use git_bot_feedback::{
     FileAnnotation, OutputVariable, RestApiClient, RestApiRateLimitHeaders, RestClientError,
     ReviewOptions, ThreadCommentOptions,
+    client::{LocalClient, init_client},
 };
 use mockito::{Matcher, Server};
 use reqwest::{
@@ -13,42 +13,6 @@ use url::Url;
 
 mod common;
 use common::logger_init;
-
-/// A dummy struct to impl RestApiClient
-#[derive(Default)]
-struct TestClient;
-
-#[async_trait]
-impl RestApiClient for TestClient {
-    async fn post_thread_comment(
-        &self,
-        _options: ThreadCommentOptions,
-    ) -> Result<(), RestClientError> {
-        Err(RestClientError::CannotCloneRequest)
-    }
-
-    fn is_pr_event(&self) -> bool {
-        false
-    }
-
-    fn write_output_variables(&self, _vars: &[OutputVariable]) -> Result<(), RestClientError> {
-        Err(RestClientError::Io {
-            task: "write output variables".into(),
-            source: std::io::Error::from(std::io::ErrorKind::InvalidFilename),
-        })
-    }
-
-    async fn cull_pr_reviews(
-        &mut self,
-        _options: &mut ReviewOptions,
-    ) -> Result<(), RestClientError> {
-        Err(RestClientError::RateLimitNoReset)
-    }
-
-    async fn post_pr_review(&mut self, _options: &ReviewOptions) -> Result<(), RestClientError> {
-        Err(RestClientError::RateLimitNoReset)
-    }
-}
 
 #[derive(Default)]
 struct RateLimitTestParams {
@@ -114,7 +78,11 @@ async fn simulate_rate_limit(test_params: &RateLimitTestParams) {
     } else {
         mock.create();
     }
-    let test_client = TestClient::default();
+    unsafe {
+        // prevent using GithubApiClient in these tests
+        std::env::set_var("GITHUB_ACTIONS", "false");
+    }
+    let test_client = init_client().unwrap();
     assert!(!test_client.is_debug_enabled());
     assert!(test_client.event_name().is_none());
     let request = test_client
@@ -215,23 +183,27 @@ async fn rate_limit_bad_count() {
 
 #[tokio::test]
 async fn dummy_coverage() {
-    let test_client = TestClient::default();
+    let mut test_client = LocalClient;
     let log_group_name = "Dummy test";
     test_client.start_log_group(log_group_name);
-    assert!(
-        test_client
-            .post_thread_comment(ThreadCommentOptions {
-                comment: "some comment text".to_string(),
-                ..Default::default()
-            })
-            .await
-            .is_err()
-    );
+    test_client
+        .post_thread_comment(ThreadCommentOptions {
+            comment: "some comment text".to_string(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
     test_client.append_step_summary("").unwrap();
     test_client
-        .write_output_variables(&[])
-        .expect_err("Not implemented for generic clients");
+        .write_output_variables(&[OutputVariable {
+            name: "key".to_string(),
+            value: "value".to_string(),
+        }])
+        .unwrap();
     assert!(!test_client.is_pr_event());
+    let mut options = ReviewOptions::default();
+    test_client.cull_pr_reviews(&mut options).await.unwrap();
+    test_client.post_pr_review(&options).await.unwrap();
     let annotation = FileAnnotation::default();
     test_client.write_file_annotations(&[annotation]).unwrap();
     test_client.end_log_group(log_group_name);
@@ -249,7 +221,7 @@ fn bad_link_header() {
     );
     logger_init();
     log::set_max_level(log::LevelFilter::Debug);
-    let test_client = TestClient::default();
+    let test_client = LocalClient;
     let result = test_client.try_next_page(&headers);
     assert!(result.is_none());
 }
@@ -267,7 +239,7 @@ fn bad_link_domain() {
     );
     logger_init();
     log::set_max_level(log::LevelFilter::Debug);
-    let test_client = TestClient::default();
+    let test_client = LocalClient;
     let result = test_client.try_next_page(&headers);
     assert!(result.is_none());
 }
@@ -283,7 +255,7 @@ fn mk_request() {
         HeaderName::from_static("key"),
         header_value.clone(),
     )]));
-    let test_client = TestClient::default();
+    let test_client = LocalClient;
     let request = test_client
         .make_api_request(
             &client,
@@ -328,7 +300,7 @@ async fn list_file_changes() {
     // setup test client, logging, and file filter
     logger_init();
     log::set_max_level(log::LevelFilter::Debug);
-    let client = TestClient::default();
+    let client = LocalClient;
     let file_filter = FileFilter::new(&[], &["toml", "md"], None);
 
     // Now get diff of HEAD and parent commit


### PR DESCRIPTION
resolves #55

Introduces a non-CI focused `ResApiClient` implementation named `LocalClient`.

Introduces a convenient function, `init_client()` that falls back to `LocalClient` if
no supported CI platform is detected.