### PR TITLE
fix!: use stricter linting rules

### DIFF
--- a/src/client/github/graphql.rs
+++ b/src/client/github/graphql.rs
@@ -208,11 +208,13 @@ impl GithubApiClient {
         // We should never reach the `default_value` in `.unwrap_or(default_value)` because
         // the repo name should always have a `/` to delimit the repo's owner and name.
         let (repo_owner, repo_name) = self.repo.split_once('/').unwrap_or(("", ""));
-        let pr_number = self
-            .pull_request
-            .as_ref()
-            .map(|i| i.number)
-            .expect("PR reviews should only be fetched for PR events.");
+        let pr_number =
+            self.pull_request
+                .as_ref()
+                .map(|i| i.number)
+                .ok_or(ClientError::MalformedEventInfo(
+                    "Unknown PR review number for PR event".to_string(),
+                ))?;
         let mut after_thread = None;
         let mut after_comment = None;
         let mut has_next_page = true;

--- a/src/client/github/mod.rs
+++ b/src/client/github/mod.rs
@@ -239,7 +239,7 @@ impl RestApiClient for GithubApiClient {
                         old = file.previous_filename.unwrap_or(file.filename.clone()),
                         new = file.filename,
                     );
-                    for (name, info) in parse_diff(&diff, file_filter, lines_changed_only) {
+                    for (name, info) in parse_diff(&diff, file_filter, lines_changed_only)? {
                         files.entry(name).or_insert(info);
                     }
                 } else if file.changes == 0 {

--- a/src/client/github/specific_api.rs
+++ b/src/client/github/specific_api.rs
@@ -145,7 +145,7 @@ impl GithubApiClient {
             self.repo,
             if self.is_pr_event() { "/issues" } else { "" },
         );
-        let base_comment_url = self.api_url.join(&repo).unwrap();
+        let base_comment_url = self.api_url.join(&repo)?;
         while let Some(ref endpoint) = comments_url {
             let request =
                 self.make_api_request(&self.client, endpoint.to_owned(), Method::GET, None, None)?;

--- a/src/client/local.rs
+++ b/src/client/local.rs
@@ -108,7 +108,7 @@ impl RestApiClient for LocalClient {
             Ok(output) => {
                 if output.status.success() {
                     let diff_str = String::from_utf8_lossy(&output.stdout).to_string();
-                    let files = parse_diff(&diff_str, file_filter, lines_changed_only);
+                    let files = parse_diff(&diff_str, file_filter, lines_changed_only)?;
                     Ok(files)
                 } else {
                     let err_msg = String::from_utf8_lossy(&output.stderr).to_string();

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -284,6 +284,9 @@ pub trait RestApiClient {
         None
     }
 
+    /// A helper function to log the response of an API request with context.
+    ///
+    /// This also dumps the response body as text if possible.
     async fn log_response(&self, response: Response, context: &str) {
         if let Err(e) = response.error_for_status_ref() {
             log::error!("{}: {e:?}", context.to_owned());

--- a/src/comments/thread_comments.rs
+++ b/src/comments/thread_comments.rs
@@ -108,6 +108,8 @@ impl ThreadCommentOptions {
 
 #[cfg(test)]
 mod test {
+    #![allow(clippy::unwrap_used)]
+
     use super::{DEFAULT_MARKER, ThreadCommentOptions};
     use chrono::NaiveDateTime;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,6 +9,8 @@ use crate::client::MAX_RETRIES;
 
 /// The possible errors emitted when parsing git diffs.
 #[derive(Debug, thiserror::Error)]
+#[cfg(feature = "file-changes")]
+#[cfg_attr(docsrs, doc(cfg(feature = "file-changes")))]
 pub enum DiffError {
     /// An error emitted when failing to compile a Regular expression pattern.
     #[error("Failed to compile regex pattern: {0}")]
@@ -40,6 +42,8 @@ pub enum OutputVariableError {
 pub enum RestClientError {
     /// Errors related to parsing git diffs.
     #[error(transparent)]
+    #[cfg(feature = "file-changes")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "file-changes")))]
     DiffError(#[from] DiffError),
 
     /// Error emitted when encountering malformed event information.

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,14 @@ use thiserror::Error;
 
 use crate::client::MAX_RETRIES;
 
+/// The possible errors emitted when parsing git diffs.
+#[derive(Debug, thiserror::Error)]
+pub enum DiffError {
+    /// An error emitted when failing to compile a Regular expression pattern.
+    #[error("Failed to compile regex pattern: {0}")]
+    RegExCompileFailed(#[from] regex::Error),
+}
+
 /// The possible errors emitted when validating an [`OutputVariable`](struct@crate::OutputVariable).
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum OutputVariableError {
@@ -30,6 +38,14 @@ pub enum OutputVariableError {
 /// The possible error emitted by the REST client API
 #[derive(Debug, Error)]
 pub enum RestClientError {
+    /// Errors related to parsing git diffs.
+    #[error(transparent)]
+    DiffError(#[from] DiffError),
+
+    /// Error emitted when encountering malformed event information.
+    #[error("Encountered malformed event info: {0}")]
+    MalformedEventInfo(String),
+
     /// Error related to making HTTP requests
     #[error(transparent)]
     Request(#[from] reqwest::Error),
@@ -37,7 +53,9 @@ pub enum RestClientError {
     /// Error related to making HTTP requests, with additional context about the request that caused the error.
     #[error("Failed to {task}: {source}")]
     RequestContext {
+        /// The task being attempted.
         task: String,
+        /// The original error being propagated.
         #[source]
         source: reqwest::Error,
     },
@@ -45,7 +63,9 @@ pub enum RestClientError {
     /// Errors related to standard I/O.
     #[error("Failed to {task}: {source}")]
     Io {
+        /// The task being attempted.
         task: String,
+        /// The original error being propagated.
         #[source]
         source: std::io::Error,
     },
@@ -92,7 +112,9 @@ pub enum RestClientError {
     /// Error emitted when failing to deserialize/serialize request/response JSON data.
     #[error("Failed to {task}: {source}")]
     Json {
+        /// The task being attempted.
         task: String,
+        /// The original error being propagated.
         #[source]
         source: serde_json::Error,
     },
@@ -100,7 +122,9 @@ pub enum RestClientError {
     /// Error emitted when failing to read an environment variable.
     #[error("Failed to get env var '{name}': {source}")]
     EnvVar {
+        /// The name of the environment variable that was attempted to be read.
         name: String,
+        /// The original error being propagated.
         #[source]
         source: std::env::VarError,
     },
@@ -158,13 +182,17 @@ impl RestClientError {
 #[derive(Debug, Error)]
 #[cfg_attr(docsrs, doc(cfg(feature = "file-changes")))]
 pub enum DirWalkError {
+    /// Error emitted when failing to read a directory entry.
     #[error("Failed to read {path}: {source}")]
     ReadDir {
+        /// The path that was attempted to be read.
         path: PathBuf,
+        /// The original error being propagated.
         #[source]
         source: std::io::Error,
     },
 
+    /// Error emitted when failing to interact with files.
     #[error(transparent)]
     OsError(#[from] std::io::Error),
 }

--- a/src/file_annotations.rs
+++ b/src/file_annotations.rs
@@ -51,11 +51,16 @@ pub struct FileAnnotation {
     pub message: String,
 }
 
+/// The severity of a [`FileAnnotation`].
 #[derive(Debug, Default)]
 pub enum AnnotationLevel {
+    /// The annotation is for debugging purposes.
     Debug,
+    /// The annotation is for informational purposes.
     #[default]
     Notice,
+    /// The annotation is for warning purposes.
     Warning,
+    /// The annotation is for error purposes.
     Error,
 }

--- a/src/file_utils/file_filter.rs
+++ b/src/file_utils/file_filter.rs
@@ -263,6 +263,8 @@ impl FileFilter {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::unwrap_used)]
+
     use crate::error::DirWalkError;
 
     use super::FileFilter;

--- a/src/file_utils/mod.rs
+++ b/src/file_utils/mod.rs
@@ -110,6 +110,10 @@ impl FileDiffLines {
         }
     }
 
+    /// Get the ranges of changed lines based on the `lines_changed_only` parameter.
+    ///
+    /// Use this to map [`Self::added_lines`] and [`Self::diff_hunks`] to a selection of
+    /// [`LinesChangedOnly`] options.
     pub fn get_ranges(&self, lines_changed_only: &LinesChangedOnly) -> Option<Vec<Range<u32>>> {
         match lines_changed_only {
             LinesChangedOnly::Diff => Some(self.diff_hunks.to_vec()),
@@ -154,6 +158,8 @@ impl FileDiffLines {
 
 #[cfg(test)]
 mod test {
+    #![allow(clippy::unwrap_used)]
+
     use super::{FileDiffLines, LinesChangedOnly};
 
     #[test]

--- a/src/git_diff.rs
+++ b/src/git_diff.rs
@@ -1,7 +1,7 @@
 use regex::Regex;
 use std::{collections::HashMap, ops::Range, path::PathBuf};
 
-use crate::{FileDiffLines, FileFilter, LinesChangedOnly};
+use crate::{FileDiffLines, FileFilter, LinesChangedOnly, error::DiffError};
 
 /// A struct to represent the header information of a diff hunk.
 pub struct DiffHunkHeader {
@@ -15,22 +15,25 @@ pub struct DiffHunkHeader {
     pub new_lines: u32,
 }
 
-fn get_filename_from_front_matter(front_matter: &str) -> Option<&str> {
-    let diff_file_name = Regex::new(r"(?m)^\+\+\+\sb?/(.*)$").unwrap();
-    let diff_renamed_file = Regex::new(r"(?m)^rename to (.*)$").unwrap();
-    let diff_binary_file = Regex::new(r"(?m)^Binary\sfiles\s").unwrap();
-    if let Some(captures) = diff_file_name.captures(front_matter) {
-        return Some(captures.get(1).unwrap().as_str());
+fn get_filename_from_front_matter(front_matter: &str) -> Result<Option<&str>, DiffError> {
+    let diff_file_name = Regex::new(r"(?m)^\+\+\+\sb?/(.*)$")?;
+    let diff_renamed_file = Regex::new(r"(?m)^rename to (.*)$")?;
+    let diff_binary_file = Regex::new(r"(?m)^Binary\sfiles\s")?;
+    if let Some(captures) = diff_file_name.captures(front_matter)
+        && let Some(name) = captures.get(1)
+    {
+        return Ok(Some(name.as_str()));
     }
     if front_matter.starts_with("similarity")
         && let Some(captures) = diff_renamed_file.captures(front_matter)
+        && let Some(name) = captures.get(1)
     {
-        return Some(captures.get(1).unwrap().as_str());
+        return Ok(Some(name.as_str()));
     }
     if !diff_binary_file.is_match(front_matter) {
         log::warn!("Unrecognized diff starting with:\n{}", front_matter);
     }
-    None
+    Ok(None)
 }
 
 /// A regex pattern used in multiple functions
@@ -42,11 +45,11 @@ static HUNK_INFO_PATTERN: &str = r"(?m)@@\s\-\d+,?\d*\s\+(\d+),?(\d*)\s@@";
 ///
 /// - the line numbers that contain additions
 /// - the ranges of lines that span each hunk
-fn parse_patch(patch: &str) -> (Vec<u32>, Vec<Range<u32>>) {
+fn parse_patch(patch: &str) -> Result<(Vec<u32>, Vec<Range<u32>>), DiffError> {
     let mut diff_hunks = Vec::new();
     let mut additions = Vec::new();
 
-    let hunk_info = Regex::new(HUNK_INFO_PATTERN).unwrap();
+    let hunk_info = Regex::new(HUNK_INFO_PATTERN)?;
     let hunk_headers = hunk_info.captures_iter(patch).collect::<Vec<_>>();
     if !hunk_headers.is_empty() {
         // skip the first split because it is anything that precedes first hunk header
@@ -66,7 +69,7 @@ fn parse_patch(patch: &str) -> (Vec<u32>, Vec<Range<u32>>) {
             }
         }
     }
-    (additions, diff_hunks)
+    Ok((additions, diff_hunks))
 }
 
 /// Parses a git `diff` string into a map of file names to their corresponding
@@ -79,10 +82,10 @@ pub fn parse_diff(
     diff: &str,
     file_filter: &FileFilter,
     lines_changed_only: &LinesChangedOnly,
-) -> HashMap<String, FileDiffLines> {
+) -> Result<HashMap<String, FileDiffLines>, DiffError> {
     let mut results = HashMap::new();
-    let diff_file_delimiter = Regex::new(r"(?m)^diff --git a/.*$").unwrap();
-    let hunk_info = Regex::new(HUNK_INFO_PATTERN).unwrap();
+    let diff_file_delimiter = Regex::new(r"(?m)^diff \-\-git a/.*$")?;
+    let hunk_info = Regex::new(HUNK_INFO_PATTERN)?;
 
     let file_diffs = diff_file_delimiter.split(diff);
     for file_diff in file_diffs {
@@ -95,11 +98,11 @@ pub fn parse_diff(
             file_diff.len()
         };
         let front_matter = &file_diff[..hunk_start];
-        if let Some(file_name) = get_filename_from_front_matter(front_matter.trim_start()) {
+        if let Some(file_name) = get_filename_from_front_matter(front_matter.trim_start())? {
             let file_name = file_name.strip_prefix('/').unwrap_or(file_name);
             let file_path = PathBuf::from(file_name);
             if file_filter.is_qualified(&file_path) {
-                let (added_lines, diff_hunks) = parse_patch(&file_diff[hunk_start..]);
+                let (added_lines, diff_hunks) = parse_patch(&file_diff[hunk_start..])?;
                 if lines_changed_only
                     .is_change_valid(!added_lines.is_empty(), !diff_hunks.is_empty())
                 {
@@ -110,12 +113,14 @@ pub fn parse_diff(
             }
         }
     }
-    results
+    Ok(results)
 }
 
 // ******************* UNIT TESTS ***********************
 #[cfg(test)]
 mod test {
+    #![allow(clippy::unwrap_used)]
+
     use super::parse_diff;
     use crate::{FileFilter, LinesChangedOnly};
 
@@ -134,7 +139,8 @@ Binary files /dev/null and b/some picture.png differ
             RENAMED_DIFF,
             &FileFilter::new(&[], &["c"], None),
             &LinesChangedOnly::Off,
-        );
+        )
+        .unwrap();
         let git_file = files.get("tests/demo/some source.c").unwrap();
         assert!(git_file.added_lines.is_empty());
         assert!(git_file.diff_hunks.is_empty());
@@ -146,7 +152,8 @@ Binary files /dev/null and b/some picture.png differ
             RENAMED_DIFF,
             &FileFilter::new(&[], &["c"], None),
             &LinesChangedOnly::Diff,
-        );
+        )
+        .unwrap();
         assert!(files.is_empty());
     }
 
@@ -166,7 +173,8 @@ rename to /tests/demo/some source.c
             // triggers code coverage of a `}` (region end)
             &FileFilter::new(&["src/*"], &["c", "cpp"], None),
             &LinesChangedOnly::On,
-        );
+        )
+        .unwrap();
         eprintln!("files: {files:#?}");
         let git_file = files.get("tests/demo/some source.c").unwrap();
         assert!(!git_file.is_line_in_diff(&1));
@@ -186,7 +194,8 @@ rename to /tests/demo/some source.c
             TYPICAL_DIFF,
             &FileFilter::new(&[], &["cpp"], None),
             &LinesChangedOnly::On,
-        );
+        )
+        .unwrap();
         assert!(!files.is_empty());
     }
 
@@ -200,7 +209,8 @@ rename to /tests/demo/some source.c
             BINARY_DIFF,
             &FileFilter::new(&[], &["png"], None),
             &LinesChangedOnly::Diff,
-        );
+        )
+        .unwrap();
         assert!(files.is_empty());
     }
 
@@ -221,7 +231,7 @@ rename to /tests/demo/some source.c
     #[test]
     fn terse_hunk_header() {
         let file_filter = FileFilter::new(&[], &["cpp"], None);
-        let files = parse_diff(TERSE_HEADERS, &file_filter, &LinesChangedOnly::Diff);
+        let files = parse_diff(TERSE_HEADERS, &file_filter, &LinesChangedOnly::Diff).unwrap();
         let file_diff = files.get("src/demo.cpp").unwrap();
         assert_eq!(file_diff.diff_hunks, vec![3..4, 5..7, 17..19]);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![doc = include_str!("../README.md")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![deny(clippy::unwrap_used, clippy::expect_used, clippy::panic, missing_docs)]
 
 pub mod client;
 pub use client::{RestApiClient, RestApiRateLimitHeaders};

--- a/src/output_variable.rs
+++ b/src/output_variable.rs
@@ -59,6 +59,8 @@ impl Display for OutputVariable {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::unwrap_used)]
+
     use super::{OutputVariable, OutputVariableError};
 
     #[test]


### PR DESCRIPTION
This forbids any `.unwrap()`, `.expect()` or `panic!()` in production code.

Also, missing doc comments (for public API) is now a lint violation.