### PR TITLE
refactor: revise `FileAnnotations` impl

### DIFF
--- a/src/client/github/mod.rs
+++ b/src/client/github/mod.rs
@@ -175,7 +175,7 @@ impl RestApiClient for GithubApiClient {
         let stdout = io::stdout();
         let mut handle = stdout.lock();
         for annotation in annotations {
-            writeln!(&mut handle, "{annotation}\n")
+            writeln!(&mut handle, "{}", annotation.fmt_github())
                 .map_err(|e| ClientError::io("write to file annotation to stdout", e))?;
         }
         handle

--- a/src/client/github/specific_api.rs
+++ b/src/client/github/specific_api.rs
@@ -13,7 +13,7 @@ use reqwest::{
     Client, Method, Url,
     header::{AUTHORIZATION, HeaderMap, HeaderValue},
 };
-use std::{collections::HashMap, env, fmt::Display, fs};
+use std::{collections::HashMap, env, fs};
 
 impl GithubApiClient {
     /// Instantiate a [`GithubApiClient`] object.
@@ -219,13 +219,16 @@ impl GithubApiClient {
     }
 }
 
-impl Display for FileAnnotation {
-    // here we translate the FileAnnotation struct into the specific string format required by Github Actions for file annotations.
-    // See [Github workflow commands documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#setting-a-debug-message).
-    //
-    // Example:
-    // ::notice file={name},line={line},col={col},endLine={endLine},endColumn={endColumn},title={title}::{message}
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl FileAnnotation {
+    /// Format the [`FileAnnotation`] struct into the specific string format compatible with Github Actions.
+    ///
+    /// See [Github workflow commands documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#setting-a-debug-message).
+    ///
+    /// Example:
+    /// ```text
+    /// ::notice file={name},line={line},col={col},endLine={endLine},endColumn={endColumn},title={title}::{message}
+    /// ```
+    pub fn fmt_github(&self) -> String {
         let mut annotation_str = format!(
             "::{}",
             match self.severity {
@@ -235,10 +238,18 @@ impl Display for FileAnnotation {
                 AnnotationLevel::Error => "error",
             }
         );
-        if !self.path.is_empty() {
+        let file_path = self
+            .path
+            .replace("\\", "/")
+            .trim_start()
+            .trim_start_matches('/')
+            .trim_start_matches("./")
+            .trim()
+            .to_string();
+        if !file_path.is_empty() {
             annotation_str.push_str(" file=");
-            annotation_str.push_str(self.path.as_str());
-            if let Some(start_line) = self.start_line {
+            annotation_str.push_str(file_path.as_str());
+            if let Some(start_line) = self.start_line.map(|l| l.max(1)) {
                 annotation_str.push_str(format!(",line={start_line}").as_str());
                 let col = self.start_column.map(|c| c.max(1));
                 if let Some(col) = col {
@@ -248,19 +259,24 @@ impl Display for FileAnnotation {
                     && end_line > start_line
                 {
                     annotation_str.push_str(format!(",endline={end_line}").as_str());
-                    if let Some(end_col) = self.end_column.map(|c| c.max(1))
-                        && col.is_none_or(|c| c < end_col)
-                    {
+                    if let Some(end_col) = self.end_column.map(|c| c.max(1)) {
                         annotation_str.push_str(format!(",endColumn={end_col}").as_str());
                     }
+                } else if let Some(end_col) = self.end_column.map(|c| c.max(1))
+                    && col.is_none_or(|c| c < end_col)
+                {
+                    annotation_str.push_str(format!(",endColumn={end_col}").as_str());
                 }
             }
-        }
-        if let Some(title) = &self.title {
-            annotation_str.push_str(",title=");
+            if let Some(title) = &self.title {
+                annotation_str.push_str(",title=");
+                annotation_str.push_str(title.as_str());
+            }
+        } else if let Some(title) = &self.title {
+            annotation_str.push_str(" title=");
             annotation_str.push_str(title.as_str());
         }
-        write!(f, "{}::{}", annotation_str, self.message)
+        format!("{annotation_str}::{}", self.message)
     }
 }
 
@@ -275,7 +291,7 @@ mod tests {
             message: "This is a debug message".to_string(),
             ..Default::default()
         };
-        assert_eq!(annotation.to_string(), "::debug::This is a debug message");
+        assert_eq!(annotation.fmt_github(), "::debug::This is a debug message");
     }
 
     #[test]
@@ -283,12 +299,12 @@ mod tests {
         let annotation = FileAnnotation {
             severity: AnnotationLevel::Warning,
             message: "This is a warning message".to_string(),
-            path: "src/main.rs".to_string(),
+            path: "/.\\src\\main.rs".to_string(),
             title: Some("Warning Title".to_string()),
             ..Default::default()
         };
         assert_eq!(
-            annotation.to_string(),
+            annotation.fmt_github(),
             "::warning file=src/main.rs,title=Warning Title::This is a warning message"
         );
     }
@@ -303,7 +319,7 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(
-            annotation.to_string(),
+            annotation.fmt_github(),
             "::error file=src/lib.rs,line=10::This is an error message"
         );
     }
@@ -319,7 +335,7 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(
-            annotation.to_string(),
+            annotation.fmt_github(),
             "::error file=src/lib.rs,line=10,col=5::This is an error message"
         );
     }
@@ -335,10 +351,11 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(
-            annotation.to_string(),
+            annotation.fmt_github(),
             "::notice file=src/lib.rs,line=10,endline=20::This is a notice message"
         );
     }
+
     #[test]
     fn annotate_file_with_line_col_span() {
         let annotation = FileAnnotation {
@@ -352,8 +369,52 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(
-            annotation.to_string(),
+            annotation.fmt_github(),
             "::notice file=src/lib.rs,line=10,col=5,endline=20,endColumn=15::This is a notice message"
         );
+    }
+
+    #[test]
+    fn annotate_file_with_col_span_on_1_line() {
+        let annotation = FileAnnotation {
+            severity: AnnotationLevel::Notice,
+            path: "src/lib.rs".to_string(),
+            message: "This is a notice message".to_string(),
+            start_line: Some(10),
+            end_line: Some(2),
+            start_column: Some(5),
+            end_column: Some(15),
+            ..Default::default()
+        };
+        assert_eq!(
+            annotation.fmt_github(),
+            "::notice file=src/lib.rs,line=10,col=5,endColumn=15::This is a notice message"
+        );
+    }
+
+    #[test]
+    fn annotate_blank_path_with_title() {
+        let annotation = FileAnnotation {
+            severity: AnnotationLevel::Debug,
+            message: "This is a debug message".to_string(),
+            title: Some("Debug Title".to_string()),
+            start_line: Some(10),
+            ..Default::default()
+        };
+        assert_eq!(
+            annotation.fmt_github(),
+            "::debug title=Debug Title::This is a debug message"
+        );
+    }
+
+    #[test]
+    fn annotate_blank_path_no_title() {
+        let annotation = FileAnnotation {
+            severity: AnnotationLevel::Debug,
+            message: "This is a debug message".to_string(),
+            start_line: Some(10),
+            ..Default::default()
+        };
+        assert_eq!(annotation.fmt_github(), "::debug::This is a debug message");
     }
 }

--- a/src/file_annotations.rs
+++ b/src/file_annotations.rs
@@ -24,7 +24,10 @@ pub struct FileAnnotation {
     ///
     /// If not provided, the annotation will be placed at the specified [`Self::start_line`] instead.
     ///
-    /// This is ignored if [`Self::path`] is blank.
+    /// This is ignored if
+    /// - [`Self::path`] is blank.
+    /// - [`Self::start_line`] is not provided.
+    /// - [`Self::end_line`] is not greater than [`Self::start_line`].
     pub end_line: Option<usize>,
 
     /// The column number where the annotation starts (1-based).
@@ -35,10 +38,10 @@ pub struct FileAnnotation {
     /// The column number where the annotation ends (1-based).
     ///
     /// This is ignored if
-    /// - the [`Self::start_line`] and [`Self::end_line`] are not provided
-    /// - the [`Self::end_line`] is less than or equal to [`Self::start_line`]
-    /// - the [`Self::start_column`] is provided but is not less than this [`Self::end_column`]
     /// - the [`Self::path`] is blank
+    /// - the [`Self::start_line`] is not provided
+    /// - the [`Self::end_line`] is not greater than to [`Self::start_line`]
+    ///   and [`Self::start_column`] is provided but is not less than this [`Self::end_column`]
     pub end_column: Option<usize>,
 
     /// The title of the annotation, which will be shown in the Git Server's UI.


### PR DESCRIPTION
Refactors `impl std::fmt::Display for FileAnnotations` into `fmt_github(&self) -> String`  method.

This is done for future support of other CI platforms where `format!("{annotation}")` may have unexpected/incompatible output.

Also reviewed the doc comments and output string format. Now, `end_column` properly accounts for line span.