### PR TITLE
build: relax dependencies' constraints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1731,11 +1731,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -1744,7 +1744,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -2174,6 +2174,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,24 +7,32 @@ repository = "https://github.com/2bndy5/git-bot-feedback"
 license-file = "LICENSE"
 
 [dependencies]
-log = "0.4.29"
-chrono = "0.4.44"
-reqwest = "0.13.2"
+log = "0.4"
+chrono = "0.4"
 serde = { version = "1", features = ["derive"] }
-serde_json = "1.0.149"
-thiserror = "2.0.18"
-tokio = { version = "1.52.0", features = ["macros", "rt-multi-thread"] }
-url = "2.5.8" # pinned to whatever reqwest uses
-regex = { version = "1.12.3", optional = true }
-fast-glob = { version = "1.0.1", optional = true }
+serde_json = "1.0"
+thiserror = "2.0"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+url = "2.5" # needs to match whatever reqwest uses
+regex = { version = "1.12", optional = true }
+fast-glob = { version = "1.0", optional = true }
 async-trait = "0.1.89"
+
+[dependencies.reqwest]
+version = "0.13"
+# As a lib, this crate should allow consumers to select their own TLS backend.
+# Reqwest's default TLS backend requires aws-lc-sys, which can be problematic depending on build env.
+default-features = false
+features = ["http2", "charset", "system-proxy"]
 
 [dev-dependencies]
 mockito = "1.7.2"
-tempfile = "3.26.0"
+tempfile = "3.27.0"
+# Its ok to use default TLS backend for dev workflows
+reqwest = { version = "0.13", features = ["default-tls"] }
 
 [build-dependencies]
-chrono = {version = "0.4.44", features = ["now"]}
+chrono = {version = "0.4", features = ["now"]}
 
 [features]
 regex = ["dep:regex"]


### PR DESCRIPTION
Relaxes dependencies that are likely shared by upstream consumers.

> [!note]
> This is designed to let consumers pick the TLS backend of their choice, via `reqwest`'s features.