### PR TITLE
fix: trim line endings from file names when parsing diff strings

### DIFF
--- a/src/git_diff.rs
+++ b/src/git_diff.rs
@@ -46,13 +46,13 @@ fn get_filename_from_front_matter(front_matter: &str) -> Result<Option<&str>, Di
     if let Some(captures) = diff_file_name.captures(front_matter)
         && let Some(name) = captures.get(1)
     {
-        return Ok(Some(name.as_str()));
+        return Ok(Some(name.as_str().trim()));
     }
     if front_matter.starts_with("similarity")
         && let Some(captures) = diff_renamed_file.captures(front_matter)
         && let Some(name) = captures.get(1)
     {
-        return Ok(Some(name.as_str()));
+        return Ok(Some(name.as_str().trim()));
     }
     if !diff_binary_file.is_match(front_matter) {
         log::warn!("Unrecognized diff starting with:\n{}", front_matter);

--- a/src/git_diff.rs
+++ b/src/git_diff.rs
@@ -46,13 +46,13 @@ fn get_filename_from_front_matter(front_matter: &str) -> Result<Option<&str>, Di
     if let Some(captures) = diff_file_name.captures(front_matter)
         && let Some(name) = captures.get(1)
     {
-        return Ok(Some(name.as_str().trim()));
+        return Ok(Some(name.as_str().trim_end_matches(['\r', '\n'])));
     }
     if front_matter.starts_with("similarity")
         && let Some(captures) = diff_renamed_file.captures(front_matter)
         && let Some(name) = captures.get(1)
     {
-        return Ok(Some(name.as_str().trim()));
+        return Ok(Some(name.as_str().trim_end_matches(['\r', '\n'])));
     }
     if !diff_binary_file.is_match(front_matter) {
         log::warn!("Unrecognized diff starting with:\n{}", front_matter);


### PR DESCRIPTION
This surfaced with a diff that used CRLF.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed filename parsing to remove trailing carriage return/newline characters from paths extracted in diff headers.
  * Improved consistency for paths shown in rename/similarity change summaries, preventing malformed or extra-line filenames caused by CR/LF formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->