### PR TITLE
fix: fail on parsing erroneous diff

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -21,6 +21,10 @@ pub enum DiffError {
     /// An error emitted when failing to compile a Regular expression pattern.
     #[error("Failed to compile regex pattern: {0}")]
     RegExCompileFailed(#[from] regex::Error),
+
+    /// An error emitted when parsing a diff fails.
+    #[error("Unrecognized diff starting with: {0}")]
+    MalformedDiffError(String),
 }
 
 /// The possible errors emitted when validating an [`OutputVariable`](struct@crate::OutputVariable).
@@ -226,7 +230,9 @@ impl From<OutputVariableError> for PyErr {
 impl From<DiffError> for PyErr {
     fn from(e: DiffError) -> Self {
         match e {
-            DiffError::RegExCompileFailed(_) => PyValueError::new_err(format!("{e:?}")),
+            DiffError::RegExCompileFailed(_) | DiffError::MalformedDiffError(_) => {
+                PyValueError::new_err(format!("{e:?}"))
+            }
         }
     }
 }

--- a/src/git_diff.rs
+++ b/src/git_diff.rs
@@ -55,7 +55,7 @@ fn get_filename_from_front_matter(front_matter: &str) -> Result<Option<&str>, Di
         return Ok(Some(name.as_str()));
     }
     if !diff_binary_file.is_match(front_matter) {
-        log::warn!("Unrecognized diff starting with:\n{}", front_matter);
+        return Err(DiffError::MalformedDiffError(front_matter.to_string()));
     }
     Ok(None)
 }
@@ -145,7 +145,21 @@ mod test {
     #![allow(clippy::unwrap_used)]
 
     use super::parse_diff;
-    use crate::{FileFilter, LinesChangedOnly};
+    use crate::{FileFilter, LinesChangedOnly, error::DiffError};
+
+    const BAD_DIFF: &str = r#"{"message":"Resource not accessible by integration"}"#;
+
+    #[test]
+    fn bad_diff() {
+        let files = parse_diff(
+            BAD_DIFF,
+            &FileFilter::new(&[], &["rs"], None),
+            &LinesChangedOnly::Diff,
+        );
+        let e = files.unwrap_err();
+        assert!(matches!(e, DiffError::MalformedDiffError(_)));
+        assert!(e.to_string().ends_with(BAD_DIFF));
+    }
 
     const RENAMED_DIFF: &str = r#"diff --git a/tests/demo/some source.cpp b/tests/demo/some source.c
 similarity index 100%

--- a/src/git_diff.rs
+++ b/src/git_diff.rs
@@ -41,23 +41,24 @@ impl DiffHunkHeader {
 
 fn get_filename_from_front_matter(front_matter: &str) -> Result<Option<&str>, DiffError> {
     let diff_file_name = Regex::new(r"(?m)^\+\+\+\sb?/(.*)$")?;
-    let diff_renamed_file = Regex::new(r"(?m)^rename to (.*)$")?;
-    let diff_binary_file = Regex::new(r"(?m)^Binary\sfiles\s")?;
     if let Some(captures) = diff_file_name.captures(front_matter)
         && let Some(name) = captures.get(1)
     {
         return Ok(Some(name.as_str()));
     }
+    let diff_renamed_file = Regex::new(r"(?m)^rename to (.*)$")?;
     if front_matter.starts_with("similarity")
         && let Some(captures) = diff_renamed_file.captures(front_matter)
         && let Some(name) = captures.get(1)
     {
         return Ok(Some(name.as_str()));
     }
-    if !diff_binary_file.is_match(front_matter) {
-        return Err(DiffError::MalformedDiffError(front_matter.to_string()));
+    let diff_binary_file = Regex::new(r"(?m)^Binary\sfiles\s")?;
+    let diff_mode_only = Regex::new(r"(?x)\Aold\ mode\ [0-7]{6}\r?\nnew\ mode\ [0-7]{6}\r?\n?\z")?;
+    if diff_mode_only.is_match(front_matter) || diff_binary_file.is_match(front_matter) {
+        return Ok(None);
     }
-    Ok(None)
+    Err(DiffError::MalformedDiffError(front_matter.to_string()))
 }
 
 /// A regex pattern used in multiple functions
@@ -236,14 +237,17 @@ rename to /tests/demo/some source.c
         assert!(!files.is_empty());
     }
 
-    const BINARY_DIFF: &str = "diff --git a/some picture.png b/some picture.png\n\
+    const IGNORED_DIFF: &str = "diff --git a/some picture.png b/some picture.png\n\
                 new file mode 100644\n\
-                Binary files /dev/null and b/some picture.png differ\n";
+                Binary files /dev/null and b/some picture.png differ\n\
+                diff --git a/script.sh b/script.sh\n\
+                old mode 100644\n\
+                new mode 100755\n";
 
     #[test]
-    fn parse_binary_diff() {
+    fn parse_ignored_diff() {
         let files = parse_diff(
-            BINARY_DIFF,
+            IGNORED_DIFF,
             &FileFilter::new(&[], &["png"], None),
             &LinesChangedOnly::Diff,
         )


### PR DESCRIPTION
Previously, a bad diff would just fall through with no resulting files and a warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed diff inputs: previously unrecognized diff headers could be skipped, but now the full diff parse fails with a clear error.
  * Error details now include the original malformed text to simplify troubleshooting.
  * Python-facing errors for malformed diff content now surface as value errors, consistent with other invalid-input cases.
* **Tests**
  * Updated and expanded diff parsing test coverage to reflect the new failure behavior for malformed inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->