### PR TITLE
perf: move option's value instead of cloning it

### DIFF
--- a/src/client/github/graphql.rs
+++ b/src/client/github/graphql.rs
@@ -430,9 +430,8 @@ impl GithubApiClient {
     ) -> Result<(), ClientError> {
         let mut next_page = Some(Url::parse_with_params(url.as_str(), [("page", "1")])?);
         let graphql_url = self.api_url.join("/graphql")?;
-        while let Some(url) = next_page {
-            let request =
-                self.make_api_request(&self.client, url.clone(), Method::GET, None, None)?;
+        while let Some(endpoint) = next_page.take() {
+            let request = self.make_api_request(&self.client, endpoint, Method::GET, None, None)?;
             let response = self
                 .send_api_request(&self.client, request, &self.rate_limit_headers)
                 .await;

--- a/src/client/github/mod.rs
+++ b/src/client/github/mod.rs
@@ -212,9 +212,8 @@ impl RestApiClient for GithubApiClient {
         };
         let mut url = Some(Url::parse_with_params(url.as_str(), &[("page", "1")])?);
         let mut files: HashMap<String, FileDiffLines> = HashMap::new();
-        while let Some(ref endpoint) = url {
-            let request =
-                self.make_api_request(&self.client, endpoint.to_owned(), Method::GET, None, None)?;
+        while let Some(endpoint) = url.take() {
+            let request = self.make_api_request(&self.client, endpoint, Method::GET, None, None)?;
             let response = self
                 .send_api_request(&self.client, request, &self.rate_limit_headers)
                 .await

--- a/src/client/github/specific_api.rs
+++ b/src/client/github/specific_api.rs
@@ -146,9 +146,8 @@ impl GithubApiClient {
             if self.is_pr_event() { "/issues" } else { "" },
         );
         let base_comment_url = self.api_url.join(&repo)?;
-        while let Some(ref endpoint) = comments_url {
-            let request =
-                self.make_api_request(&self.client, endpoint.to_owned(), Method::GET, None, None)?;
+        while let Some(endpoint) = comments_url.take() {
+            let request = self.make_api_request(&self.client, endpoint, Method::GET, None, None)?;
             let result = self
                 .send_api_request(&self.client, request, &self.rate_limit_headers)
                 .await;


### PR DESCRIPTION
When doing pagination, the next URL is saved in an `Option`. The `while` loop was broken when `try_next_page()` returned `None`, but URL ownership still belonged to the `Option` instance.

By using `Option::take()`, ownership is moved into the loop, and it is more explicit that the `while` loop ends when the URL is used. No more reference handling and cloning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved how paginated API requests are handled across several GitHub-related flows, reducing unnecessary cloning and simplifying request iteration.
  * No user-facing behavior changes are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->