### PR TITLE
test: reuse `EventType` enum for certain integration tests

### DIFF
--- a/tests/common.rs
+++ b/tests/common.rs
@@ -23,3 +23,20 @@ impl log::Log for Logger {
 pub fn logger_init() {
     let _ = log::set_logger(&Logger);
 }
+
+#[allow(dead_code, reason = "This is used by most tests but not all of them")]
+#[derive(Debug, PartialEq, Default)]
+pub enum EventType {
+    #[default]
+    Push,
+    PullRequest,
+}
+
+impl std::fmt::Display for EventType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Push => write!(f, "push"),
+            Self::PullRequest => write!(f, "pull_request"),
+        }
+    }
+}

--- a/tests/github_file_annotations.rs
+++ b/tests/github_file_annotations.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "github")]
 use git_bot_feedback::{FileAnnotation, client::init_client};
 use mockito::Server;
 use std::env;

--- a/tests/github_file_changes.rs
+++ b/tests/github_file_changes.rs
@@ -1,7 +1,7 @@
-#![cfg(feature = "file-changes")]
+#![cfg(all(feature = "file-changes", feature = "github"))]
 use chrono::Utc;
 mod common;
-use common::logger_init;
+use common::{EventType, logger_init};
 use mockito::{Matcher, Server};
 use tempfile::{NamedTempFile, TempDir};
 
@@ -9,13 +9,6 @@ use git_bot_feedback::{
     DiffHunkHeader, FileFilter, LinesChangedOnly, RestClientError, client::init_client,
 };
 use std::{env, io::Write, path::Path};
-
-#[derive(PartialEq, Default)]
-enum EventType {
-    #[default]
-    Push,
-    PullRequest,
-}
 
 #[derive(Default)]
 struct TestParams {

--- a/tests/github_output_variables.rs
+++ b/tests/github_output_variables.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "github")]
 use git_bot_feedback::{OutputVariable, RestClientError, client::init_client};
 use mockito::Server;
 use std::{env, io::Read, path::Path};

--- a/tests/github_pr_reviews.rs
+++ b/tests/github_pr_reviews.rs
@@ -1,13 +1,14 @@
+#![cfg(feature = "github")]
 use chrono::Utc;
 use git_bot_feedback::{
     RestClientError, ReviewAction, ReviewComment, ReviewOptions, client::init_client,
 };
 use mockito::{Matcher, Server};
-use std::{collections::HashMap, env, fmt::Display, fs, io::Write, path::Path};
+use std::{collections::HashMap, env, fs, io::Write, path::Path};
 use tempfile::{NamedTempFile, TempDir};
 
 mod common;
-use common::logger_init;
+use common::{EventType, logger_init};
 
 const MARKER: &str = "<!-- git-bot-feedback -->\n";
 const SHA: &str = "deadbeef";
@@ -23,21 +24,6 @@ const QUERY_REVIEW_THREADS: &str = r#"(?s).*"query":"query.*reviewThreads.*"#;
 const MUTATION_DELETE: &str = r#"(?s).*"query":"mutation.*deletePullRequestReviewComment.*"#;
 const MUTATION_RESOLVE_THREAD: &str = r#"(?s).*"query":"mutation.*resolveReviewThread.*"#;
 const MUTATION_HIDE_SUMMARY: &str = r#"(?s).*"query":"mutation.*minimizeComment.*"#;
-
-#[derive(PartialEq, Clone, Copy, Debug)]
-enum EventType {
-    Push,
-    PullRequest,
-}
-
-impl Display for EventType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Push => write!(f, "push"),
-            Self::PullRequest => write!(f, "pull_request"),
-        }
-    }
-}
 
 struct TestParams {
     event_t: EventType,

--- a/tests/github_step_summary.rs
+++ b/tests/github_step_summary.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "github")]
 use git_bot_feedback::{RestClientError, client::init_client};
 use mockito::Server;
 use std::{env, io::Read, path::Path};

--- a/tests/github_thread_comments.rs
+++ b/tests/github_thread_comments.rs
@@ -1,13 +1,14 @@
+#![cfg(feature = "github")]
 use chrono::Utc;
 use git_bot_feedback::{
     CommentKind, CommentPolicy, RestClientError, ThreadCommentOptions, client::init_client,
 };
 use mockito::{Matcher, Server};
-use std::{env, fmt::Display, io::Write, path::Path};
+use std::{env, io::Write, path::Path};
 use tempfile::{NamedTempFile, TempDir};
 
 mod common;
-use common::logger_init;
+use common::{EventType, logger_init};
 
 const MARKER: &str = "<!-- git-bot-feedback -->\n";
 const SHA: &str = "deadbeef";
@@ -18,21 +19,6 @@ const MOCK_ASSETS_PATH: &str = "tests/assets/thread_comment/github/";
 
 const RESET_RATE_LIMIT_HEADER: &str = "x-ratelimit-reset";
 const REMAINING_RATE_LIMIT_HEADER: &str = "x-ratelimit-remaining";
-
-#[derive(PartialEq, Clone, Copy, Debug)]
-enum EventType {
-    Push,
-    PullRequest,
-}
-
-impl Display for EventType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Push => write!(f, "push"),
-            Self::PullRequest => write!(f, "pull_request"),
-        }
-    }
-}
 
 struct TestParams {
     event_t: EventType,

--- a/tests/local_client.rs
+++ b/tests/local_client.rs
@@ -1,7 +1,7 @@
 use chrono::Utc;
 use git_bot_feedback::{
-    FileAnnotation, FileFilter, OutputVariable, RestApiClient, RestApiRateLimitHeaders,
-    RestClientError, ReviewOptions, ThreadCommentOptions,
+    FileAnnotation, OutputVariable, RestApiClient, RestApiRateLimitHeaders, RestClientError,
+    ReviewOptions, ThreadCommentOptions,
     client::{LocalClient, init_client},
 };
 use mockito::{Matcher, Server};
@@ -388,8 +388,11 @@ async fn list_file_changes() {
     assert_eq!(changes.len(), 2);
 }
 
+#[cfg(feature = "file-changes")]
 #[test]
 fn walk_dir_strip_prefix() {
+    use git_bot_feedback::FileFilter;
+
     let extensions = vec!["json"];
     logger_init();
     log::set_max_level(log::LevelFilter::Debug);


### PR DESCRIPTION
Also guards certain integration tests with the required feature(s).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a shared event type used across GitHub-related test scenarios, improving consistency in event handling.

* **Bug Fixes**
  * Tightened feature gating so GitHub-specific tests only run when the GitHub feature is enabled.
  * Updated local file-change test coverage to run only when the matching feature is enabled.

* **Tests**
  * Expanded GitHub workflow test coverage for output variables, step summaries, file annotations, thread comments, and pull request reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->