### PR TITLE
fix: output only diff using `git show`

### DIFF
--- a/src/client/local.rs
+++ b/src/client/local.rs
@@ -111,7 +111,7 @@ impl RestApiClient for LocalClient {
         if ignore_index {
             // When ignoring the index, we want to compare
             // the working directory changes, not the staged changes.
-            diff_args.push("--format=%b".to_string());
+            diff_args.push("--format=".to_string());
             git_sub_cmd.push("show");
         } else {
             git_sub_cmd.push("diff");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of changed-file listings when the index is ignored, ensuring file changes are parsed more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->